### PR TITLE
black formatting and flake8 linting

### DIFF
--- a/m4atool/__init__.py
+++ b/m4atool/__init__.py
@@ -1,2 +1,3 @@
 from .m4atool import M4a
-__all__ = ['M4a']
+
+__all__ = ["M4a"]

--- a/m4atool/cli.py
+++ b/m4atool/cli.py
@@ -1,6 +1,8 @@
 import argparse
 from m4atool import M4a
 import os
+import sys
+
 
 def find_m4a_files(basedir, filelist):
     """Return list of files to manipulate."""
@@ -12,29 +14,29 @@ def find_m4a_files(basedir, filelist):
         sys.exit(f"{basedir} is not a directory")
 
     for file in files:
-        ## preserve basedir in filename        
+        # preserve basedir in filename
         file = f"{basedir}/{file}"
         if not os.path.isdir(file):
             if os.path.splitext(file)[1] == M4a.EXT:
                 filelist.append(file)
 
-        ## if we are a directory, recurse
+        # if we are a directory, recurse
         elif os.path.isdir(file):
-            filelist = list_files(file, filelist)
+            filelist = find_m4a_files(file, filelist)
 
-    return filelist  
+    return filelist
 
 
 def arg_parse():
-    parser = argparse.ArgumentParser(description='Directory of encoded files')
-    parser.add_argument('--basedir', '-b', required=True, help=f'base directory containing m4a files')
-    parser.add_argument('--debug', '-d', action='store_true', default=False, help=f'debug')
-    parser.add_argument('--rename', '-r', action='store_true', help=f'rename')
-    parser.add_argument('--sanitize', '-s', action='store_true', help=f'sanitize tags')
-    parser.add_argument('--album', default=None, help=f'album name')
-    parser.add_argument('--artist', default=None, help=f'artist name')
-    parser.add_argument('--genre', default=None, help=f'genre')
-    args = parser.parse_args()
+    prs = argparse.ArgumentParser(description="Directory of encoded files")
+    prs.add_argument("--basedir", "-b", required=True, help="base directory")
+    prs.add_argument("--debug", "-d", action="store_true", default=False, help="debug")
+    prs.add_argument("--rename", "-r", action="store_true", help="rename")
+    prs.add_argument("--sanitize", "-s", action="store_true", help="sanitize tags")
+    prs.add_argument("--album", default=None, help="album name")
+    prs.add_argument("--artist", default=None, help="artist name")
+    prs.add_argument("--genre", default=None, help="genre")
+    args = prs.parse_args()
     return args
 
 
@@ -47,18 +49,18 @@ def main():
         if args.artist:
             m4a.set_artist(args.artist)
 
-        if args.sanitize:
-            m4a.sanitize_tags()
-
         if args.album:
-           m4a.set_album(args.album)
+            m4a.set_album(args.album)
 
         if args.genre:
-           m4a.set_genre(args.genre)
+            m4a.set_genre(args.genre)
+
+        if args.sanitize:
+            m4a.sanitize_tags()
 
         if args.rename:
             m4a.rename()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/m4atool/m4atool.py
+++ b/m4atool/m4atool.py
@@ -2,50 +2,46 @@ import logging
 from mutagen import mp4
 import pathlib
 import re
-import string
 import shutil
-import sys
+
 
 class M4a:
-    ## apple lossless tags names
-    ALBUM = '©alb'
-    ALBUM_SORT_ORDER = 'soal'
-    ALBUM_ARTIST = 'aART'
-    ARTIST = '©ART'
-    ARTIST_SORT_ORDER = 'soar'
-    GENRE = '©gen'
-    TRACK_NUMBER = 'trkn'
-    TRACK_TITLE = '©nam'
-    TRACK_TITLE_SORT_ORDER = 'sonm'
-    YEAR = '©day'
-    EXT = '.m4a'
-
+    # apple lossless tags names
+    ALBUM = "©alb"
+    ALBUM_SORT_ORDER = "soal"
+    ALBUM_ARTIST = "aART"
+    ARTIST = "©ART"
+    ARTIST_SORT_ORDER = "soar"
+    GENRE = "©gen"
+    TRACK_NUMBER = "trkn"
+    TRACK_TITLE = "©nam"
+    TRACK_TITLE_SORT_ORDER = "sonm"
+    YEAR = "©day"
+    EXT = ".m4a"
 
     def __init__(self, filename, debug=False):
-        self.filename =  str(pathlib.Path(filename).resolve())
+        self.filename = str(pathlib.Path(filename).resolve())
         self.basedir = str(pathlib.Path(filename).parent.resolve())
         self.debug = debug
 
         log_level = logging.DEBUG if self.debug else logging.INFO
-        logging.basicConfig(level=log_level, format='%(asctime)s %(filename)s %(funcName)s %(message)s')
+        log_format = "%(asctime)s %(filename)s %(funcName)s %(message)s"
+        logging.basicConfig(level=log_level, format=log_format)
 
         try:
             self.m4a = mp4.MP4(self.filename)
         except mp4.MP4StreamInfoError:
             logging.info(f"{self.filename} is not an m4a")
 
-
     def generate_filename(self) -> str:
         """Generate new filename from existing tags."""
-        for tag_name in [self.ARTIST, self.TRACK_TITLE]:
-            self.sanitize_tag(tag_name)
-
+        # Tags must be sanitized to ensure reasonable filenames.
+        self.sanitize_tags()
         artist = self.m4a.tags[self.ARTIST][0]
         track_title = self.m4a.tags[self.TRACK_TITLE][0]
-        ## pad track number with leading zero if single digit
-        track_number = str(self.m4a.tags[self.TRACK_NUMBER][0][0]).zfill(2)        
+        # Pad track number with leading zero if single digit.
+        track_number = str(self.m4a.tags[self.TRACK_NUMBER][0][0]).zfill(2)
         return f"{self.basedir}/{track_number} {artist} - {track_title}.m4a"
-
 
     def rename(self) -> str:
         """Rename m4a lossless file."""
@@ -56,63 +52,78 @@ class M4a:
                 shutil.move(self.filename, newname)
                 self.filename = newname
 
+            except FileNotFoundError:
+                logging.debug(f"{newname} not found")
+
             except PermissionError:
                 logging.debug(f"cannot rename {self.filename} to {newname}")
 
         return newname
 
-
     def sanitize_tag(self, tag: str) -> str:
         """Sanitize characters in tag."""
-        ## convert square brackets to parentheses
-        tag = tag.translate(tag.maketrans('[]', '()'))
-        ## this needs lookaheads/lookbehinds for whitespace
-        tag = tag.replace('-', ' -- ')
-        tag = tag.replace('/', ' -- ')
-        ## capitalize lower case words in tag
-        tag = ' '.join([word.title() if not re.search(r'^\(?[0-9A-Z]', word) else word for word in tag.split()])
-        return tag
+        # This sequence is used as a separator to replace certain characters.
+        separator = " -- "
 
+        # Replace single dash with whitespace padding.
+        dash_rgx = re.compile(r"(?<=[^-]{1,1})\s+-\s*(?=[^-]+)")
+        tag = re.sub(dash_rgx, separator, tag)
+
+        # Replace forward slashes with separator character.
+        slash_rgx = re.compile(r"(?<=[^\/]{1,1})\s*\/+\s*(?=[^\/]+)")
+        tag = re.sub(slash_rgx, separator, tag)
+
+        # Convert square brackets to parentheses.
+        tag = tag.translate(tag.maketrans("[]", "()"))
+
+        # capitalize lower case words in tag
+        tag = " ".join(
+            [
+                word.title() if not re.search(r"^\(?[0-9A-Z]", word) else word
+                for word in tag.split()
+            ]
+        )
+        return tag
 
     def sanitize_tags(self) -> None:
         """Sanitize several tags to follow a consistent format."""
-        for tag_name in [self.ALBUM,
-                         self.ALBUM_SORT_ORDER,
-                         self.ALBUM_ARTIST,
-                         self.ARTIST,
-                         self.ARTIST_SORT_ORDER,
-                         self.TRACK_TITLE,
-                         self.TRACK_TITLE_SORT_ORDER]:
+        tag_names = (
+            M4a.ALBUM,
+            M4a.ALBUM_SORT_ORDER,
+            M4a.ALBUM_ARTIST,
+            M4a.ARTIST,
+            M4a.ARTIST_SORT_ORDER,
+            M4a.TRACK_TITLE,
+            M4a.TRACK_TITLE_SORT_ORDER,
+        )
+        for tag_name in tag_names:
             try:
-                clean_tag = self.sanitize_tag(self.m4a.tags[tag_name][0])    
+                clean_tag = self.sanitize_tag(self.m4a.tags[tag_name][0])
                 self.set_tag(tag_name, clean_tag)
             except KeyError:
                 logging.debug(f"{self.filename} tag name {tag_name} not found")
-
 
     def set_tag(self, tag_name: str, tag_value: str) -> None:
         """Override existing tag value."""
         try:
             if not self.m4a.tags[tag_name][0] == tag_value:
-                logging.debug(f"{self.filename}: setting {tag_name} to {tag_value}")
+                log_message = f"{self.filename}: set {tag_name} to {tag_value}"
+                logging.debug(log_message)
                 self.m4a.tags[tag_name][0] = tag_value
                 self.m4a.save()
 
         except KeyError:
-           logging.debug(f"{self.filename} {tag_name} not found.")
-
+            logging.debug(f"{self.filename} {tag_name} not found.")
 
     def set_album(self, album: str) -> None:
         """Update several apple lossless tags for album."""
         for tag in self.ALBUM, self.ALBUM_SORT_ORDER:
             self.set_tag(tag, album)
 
-
     def set_artist(self, artist: str) -> None:
         """Update several apple lossless tags for artist."""
         for tag in self.ARTIST, self.ARTIST_SORT_ORDER, self.ALBUM_ARTIST:
             self.set_tag(tag, artist)
-
 
     def set_genre(self, genre: str) -> None:
         """Update apple lossless tags for genre."""

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,3 @@
 mutagen
+flake8
+black

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+# Recommend matching the black line length (default 88),
+# rather than using the flake8 default of 79:
+max-line-length = 88
+extend-ignore =
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd .. 
+# Format python code with black.
+for dir in m4atool tests; do
+    python -m black $dir
+done
+
+# Lint python code with flake8.
+for dir in m4atool tests; do
+    python -m flake8 $dir
+done
+
+# run unit tests
+cd tests
+python -m unittest test_m4a.py

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd .. 
+# format python code with black
+python -m black m4atool && black tests
+
+# lint python code with flake8
+python -m flake8
+
+# run unit tests
+cd tests
+python -m unittest test_m4a.py

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
 cd .. 
-# format python code with black
-python -m black m4atool && black tests
+# Format python code with black.
+for dir in m4atool tests; do
+    python -m black $dir
+done
 
-# lint python code with flake8
-python -m flake8
+# Lint python code with flake8.
+for dir in m4atool tests; do
+    python -m flake8 $dir
+done
 
 # run unit tests
 cd tests

--- a/tests/test_m4a.py
+++ b/tests/test_m4a.py
@@ -25,10 +25,22 @@ class M4ATestCase(unittest.TestCase):
         os.remove(filename)
 
     def test_sanitize_tag(self):
-        """Test sanitization of tag."""
+        """Test sanitization of dash and blackslash characters in tags."""
         lossless = self.get_lossless()
         dirty_tag = "speak For the earth [live on WFMU]"
         clean_tag = "Speak For The Earth (Live On WFMU)"
+        self.assertEqual(lossless.sanitize_tag(dirty_tag), clean_tag)
+        words = ["foo - bar ", "foo -bar", "foo/bar", "foo // bar", "foo -- bar"]
+        for word in words:
+            self.assertEqual(lossless.sanitize_tag(word), "Foo -- Bar")
+
+        self.cleanup(lossless.filename)
+
+    def test_sanitize_tag_backslash(self):
+        """Test sanitization of square brackets in tag."""
+        lossless = self.get_lossless()
+        dirty_tag = "speak For the earth [demo/WFMU]"
+        clean_tag = "Speak For The Earth (Demo -- WFMU)"
         self.assertEqual(lossless.sanitize_tag(dirty_tag), clean_tag)
         self.cleanup(lossless.filename)
 

--- a/tests/test_m4a.py
+++ b/tests/test_m4a.py
@@ -32,6 +32,7 @@ class M4ATestCase(unittest.TestCase):
         self.assertEqual(lossless.sanitize_tag(dirty_tag), clean_tag)
         words = ["foo - bar ", "foo -bar", "foo/bar", "foo // bar", "foo -- bar"]
         for word in words:
+            print(f"{word} --> {lossless.sanitize_tag(word)}")
             self.assertEqual(lossless.sanitize_tag(word), "Foo -- Bar")
 
         self.cleanup(lossless.filename)
@@ -41,6 +42,7 @@ class M4ATestCase(unittest.TestCase):
         lossless = self.get_lossless()
         dirty_tag = "speak For the earth [demo/WFMU]"
         clean_tag = "Speak For The Earth (Demo -- WFMU)"
+        print(f"{dirty_tag} --> {clean_tag}")
         self.assertEqual(lossless.sanitize_tag(dirty_tag), clean_tag)
         self.cleanup(lossless.filename)
 

--- a/tests/test_m4a.py
+++ b/tests/test_m4a.py
@@ -25,10 +25,24 @@ class M4ATestCase(unittest.TestCase):
         os.remove(filename)
 
     def test_sanitize_tag(self):
-        """Test sanitization of tag."""
+        """Test sanitization of dash and blackslash characters in tags."""
         lossless = self.get_lossless()
         dirty_tag = "speak For the earth [live on WFMU]"
         clean_tag = "Speak For The Earth (Live On WFMU)"
+        self.assertEqual(lossless.sanitize_tag(dirty_tag), clean_tag)
+        words = ["foo - bar ", "foo -bar", "foo/bar", "foo // bar", "foo -- bar"]
+        for word in words:
+            print(f"{word} --> {lossless.sanitize_tag(word)}")
+            self.assertEqual(lossless.sanitize_tag(word), "Foo -- Bar")
+
+        self.cleanup(lossless.filename)
+
+    def test_sanitize_tag_backslash(self):
+        """Test sanitization of square brackets in tag."""
+        lossless = self.get_lossless()
+        dirty_tag = "speak For the earth [demo/WFMU]"
+        clean_tag = "Speak For The Earth (Demo -- WFMU)"
+        print(f"{dirty_tag} --> {clean_tag}")
         self.assertEqual(lossless.sanitize_tag(dirty_tag), clean_tag)
         self.cleanup(lossless.filename)
 


### PR DESCRIPTION
- lints python code with `flake8`
- formats python code using `black`
- provides improved regexes for handling dash and backslash characters in tags.
- provides better tests for tag sanitization.
- provides shell script for running unit tests.